### PR TITLE
Variational AutoEncoder (VAE)

### DIFF
--- a/examples/vae/README.txt
+++ b/examples/vae/README.txt
@@ -1,0 +1,2 @@
+Variational Autoencoder (VAE) use cases
+---------------------------------------

--- a/examples/vae/vae_conditional_1.py
+++ b/examples/vae/vae_conditional_1.py
@@ -128,7 +128,7 @@ class Encoder(nn.Module):
         z_mu = self.mu(hidden)
         # z_mu is of shape [batch_size, latent_dim]
         z_var = self.var(hidden)
-        # z_var is of shape [batch_size, latent_dim]
+        # z_var is of shape [batch_size, latent_dim]: this is log(var)
 
         return z_mu, z_var
 
@@ -198,6 +198,9 @@ class CVAE(nn.Module):
         # sample a latent vector from the latent space - using the
         # reparameterization trick
         # sample from the distribution having latent parameters z_mu, z_var
+        # the reason we exponentiate is because we need the variance to be
+        # positive. Any activation function whose range is the positive numbers
+        # could be used here.
         std = torch.exp(z_var / 2)
         eps = torch.randn_like(std)
         x_sample = eps.mul(std).add_(z_mu)

--- a/examples/vae/vae_conditional_1.py
+++ b/examples/vae/vae_conditional_1.py
@@ -1,0 +1,331 @@
+"""
+Conditional Variational AutoEncoder (VAE)
+=========================================
+
+Credit: A Grigis
+
+Based on:
+
+- https://ravirajag.dev
+
+This tutorial is for the intuition of simple Variational Autoencoder(VAE)
+implementation in pynet.
+After reading this tutorial, you'll understand the technical details needed to
+implement conditional VAE.
+The main difference from the vanilla VAE is, in the vanilla case we generate
+image randomly, and here we can condition for which number we want to generate
+the image.
+
+Let’s begin with importing stuffs:
+"""
+
+import os
+import sys
+if "CI_MODE" in os.environ:
+    sys.exit()
+
+import numpy as np
+from scipy import ndimage
+import torch
+import torch.nn as nn
+import torch.nn.functional as func
+from pynet.datasets import DataManager, fetch_minst
+from pynet.interfaces import DeepLearningInterface
+from pynet.plotting import Board, update_board
+
+
+#############################################################################
+# The model will be trained on MNIST - handwritten digits dataset. The input
+# is an image in R(28×28).
+
+def flatten(arr):
+    return arr.flatten()
+
+data = fetch_minst(datasetdir="/neurospin/nsap/datasets/minst")
+manager = DataManager(
+    input_path=data.input_path,
+    metadata_path=data.metadata_path,
+    labels="label",
+    stratify_label="label",
+    number_of_folds=10,
+    batch_size=64,
+    test_size=0,
+    input_transforms=[flatten],
+    add_input=True,
+    sample_size=1)
+
+
+#############################################################################
+# The Model
+# ---------
+#
+# The model is composed of two sub-networks:
+# 1. Given x (image), encode it into a distribution over the latent space -
+#    referred to as Q(z|x).
+# 2. Given z in latent space (code representation of an image), decode it into
+#    the image it represents - referred to as f(z).
+#
+# We want to enforce some of the latent dimensions to encode the digit found
+# in an image. In the vanilla VAE case we don't care what
+# information each dimension of the latent space holds. The model can learn
+# to encode whatever information it finds valuable for its task. Since we're
+# familiar with the dataset, we know the digit type should be important.
+# We want to help the model by providing it with this information. Moreover,
+# we'll use this information to generate images conditioned on the digit type,
+# as we will see later.
+# 
+# Given the digit type, we'll encode it using one hot encoding, that is, a
+# vector of size 10. These 10 numbers will be concatenated into the latent 
+# vector, so when decoding that vector into an image, the model will make use
+# of the digit information.
+#
+# There are two ways to provide the model with a one hot encoding vector:
+# 1. Add it as an input to the model.
+# 2. Add it as a label so the model will have to predict it by itself: add
+#    another sub-network that predicts a vector of size 10 where the loss is
+#    the cross entropy with the expected one hot vector.
+#
+# We'll go with the first option first.
+
+def idx2onehot(idx, n):
+    """ Given a class label, we will convert it into one-hot encoding.
+    """
+    assert idx.ndim == 1
+    assert torch.max(idx).item() < n
+    idx = idx.view(-1, 1)
+    onehot = torch.zeros(idx.size(0), n)
+    onehot.scatter_(1, idx.data, 1)
+
+    return onehot
+
+class Encoder(nn.Module):
+    """ This the encoder part of VAE.
+    """
+    def __init__(self, input_dim, hidden_dim, latent_dim, n_classes):
+        """ Init class.
+
+        Parameters
+        ----------
+        input_dim: int
+            the size of input (in case of MNIST 28 * 28).
+        hidden_dim: int
+            the size of hidden dimension.
+        latent_dim: int
+            the latent dimension.
+        n_classes: int
+            the number of classes (dimension of one-hot representation of   
+            labels).
+        """
+        super().__init__()
+        self.linear = nn.Linear(input_dim + n_classes, hidden_dim)
+        self.mu = nn.Linear(hidden_dim, latent_dim)
+        self.var = nn.Linear(hidden_dim, latent_dim)
+
+    def forward(self, x):
+        # x is of shape [batch_size, input_dim]
+        hidden = func.relu(self.linear(x))
+        # hidden is of shape [batch_size, hidden_dim]
+        z_mu = self.mu(hidden)
+        # z_mu is of shape [batch_size, latent_dim]
+        z_var = self.var(hidden)
+        # z_var is of shape [batch_size, latent_dim]
+
+        return z_mu, z_var
+
+class Decoder(nn.Module):
+    """ This the decoder part of VAE
+    """
+    def __init__(self, latent_dim, hidden_dim, output_dim, n_classes):
+        """ Init class.
+
+        Parameters
+        ----------
+        latent_dim: int
+            the latent size.
+        hidden_dim: int
+            the size of hidden dimension.
+        output_dim: int
+            the output dimension (in case of MNIST it is 28 * 28).
+        n_classes: int
+            the number of classes (dimension of one-hot representation of   
+            labels).
+        """
+        super().__init__()
+        self.latent_to_hidden = nn.Linear(latent_dim + n_classes, hidden_dim)
+        self.hidden_to_out = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x):
+        # x is of shape [batch_size, latent_dim]
+        hidden = func.relu(self.latent_to_hidden(x))
+        # hidden is of shape [batch_size, hidden_dim]
+        predicted = torch.sigmoid(self.hidden_to_out(hidden))
+        # predicted is of shape [batch_size, output_dim]
+
+        return predicted
+
+
+class CVAE(nn.Module):
+    """ This is the conditional VAE.
+    """
+    def __init__(self, input_dim, hidden_dim, latent_dim, n_classes):
+        """ Init class.
+
+        Parameters
+        ----------
+        input_dim: int
+            the size of input (in case of MNIST 28 * 28).
+        hidden_dim: int
+            the size of hidden dimension.
+        latent_dim: int
+            the latent dimension.
+        n_classes: int
+            the number of classes (dimension of one-hot representation of   
+            labels).
+        """
+        super(CVAE, self).__init__()
+        self.encoder = Encoder(input_dim, hidden_dim, latent_dim, n_classes)
+        self.decoder = Decoder(latent_dim, hidden_dim, input_dim, n_classes)
+        self.n_classes = n_classes
+
+    def forward(self, x, y):
+        # convert y into one-hot encoding
+        y = idx2onehot(y, n=self.n_classes)
+        y = y.to(x.device)
+
+        # encode an image into a distribution over the latent space
+        z_mu, z_var = self.encoder(torch.cat((x, y), dim=1))
+
+        # sample a latent vector from the latent space - using the
+        # reparameterization trick
+        # sample from the distribution having latent parameters z_mu, z_var
+        std = torch.exp(z_var / 2)
+        eps = torch.randn_like(std)
+        x_sample = eps.mul(std).add_(z_mu)
+
+        # decode the latent vector - concatenated to the digits
+        # classification into an image
+        predicted = self.decoder(torch.cat((x_sample, y), dim=1))
+
+        return predicted, {"z_mu": z_mu, "z_var": z_var, "y": y}
+
+
+#############################################################################
+# Loss
+# ----
+#
+# VAE consists of two loss functions:
+# 1. Reconstruction loss: how well we can reconstruct the image
+# 2. KL divergence: how off the distribution over the latent space is 
+#    from the prior. Given the prior is a standard Gaussian and the inferred
+#    distribution is a Gaussian with a diagonal covariance matrix,
+#    the KL-divergence becomes analytically solvable.
+
+class DecodeLoss(object):
+    def __init__(self):
+        super(DecodeLoss, self).__init__()
+        self.layer_outputs = None
+
+    def __call__(self, x_sample, x, y):
+        if self.layer_outputs is None:
+            raise ValueError("The model needs to return the latent space "
+                             "distribution parameters z_mu, z_var.")
+        z_mu = self.layer_outputs["z_mu"]
+        z_var = self.layer_outputs["z_var"]
+        # reconstruction loss
+        recon_loss = func.binary_cross_entropy(x_sample, x, reduction="sum")
+        # KL divergence loss
+        kl_loss = 0.5 * torch.sum(torch.exp(z_var) + z_mu**2 - 1.0 - z_var)
+
+        return recon_loss + kl_loss
+
+
+#############################################################################
+# Training
+# --------
+#
+# We'll train the model to optimize the losses using Adam optimizer.
+#
+# At the end of every epoch we'll sample latent vectors and decode them into
+# images, so we can visualize how the generative power of the model improves
+# over the epochs. The sampling method is as follows:
+# 1. Deterministically set the dimensions which are used for digit
+#    classification according to the digit we want to generate an image for.
+#    If for example we want to generate an image of the digit 2, these
+#    dimensions will be set to [0010000000].
+# 2. Randomly sample the other dimensions according to the prior - a
+#    multivariate Gaussian. We'll use these sampled values for all the
+#    different digits we generate in a given epoch. This way we can have a
+#    feeling of what is encoded in the other dimensions, for example stroke
+#    style.
+#
+# The intuition behind step 1 is that after convergence the model should be
+# able to classify the digit in an input image using these dimensions. On the
+# other hand, these dimensions are also used in the decoding step to generate
+# the image. It means the decoder sub-network learns that when these
+# dimensions have the values corresponding to the digit 2, it should generate
+# an image of that digit. Therefore, if we manually set these dimensions to
+# contain the information of the digit 2, we'll get a generated image of that
+# digit.
+
+def prepare_pred(y_pred):
+    y_pred = y_pred[:3]
+    y_pred = y_pred.reshape(-1, 28, 28)
+    y_pred = np.asarray([ndimage.zoom(arr, 5, order=0) for arr in y_pred])
+    y_pred = np.expand_dims(y_pred, axis=1)
+    y_pred = (y_pred / y_pred.max()) * 255
+    return y_pred
+
+def sampling(signal):
+    """ Sample from the distribution and generate a image.
+    """
+    device = signal.object.device
+    model = signal.object.model
+    board = signal.object.board
+    # sample and generate a image
+    z = torch.randn(1, 20).to(device).repeat(10, 1)
+    y = torch.eye(10).to(device, dtype=z.dtype)
+    z = torch.cat((z, y), dim=1)
+    # run only the decoder
+    reconstructed_img = model.decoder(z)
+    img = reconstructed_img.view(-1, 28, 28).detach().numpy()
+    # display result
+    img = np.asarray([ndimage.zoom(arr, 5, order=0) for arr in img])
+    img = np.expand_dims(img, axis=1)
+    img = (img / img.max()) * 255
+    board.viewer.images(
+        img,
+        opts={
+            "title": "sampling",
+            "caption": "sampling"},
+        win="sampling")    
+
+model = CVAE(input_dim=(28 * 28), hidden_dim=128, latent_dim=20, n_classes=10)
+interface = DeepLearningInterface(
+    model=model,
+    optimizer_name="Adam",
+    learning_rate=0.001,
+    loss=DecodeLoss(),
+    add_labels=True)
+interface.board = Board(
+    port=8097, host="http://localhost", env="vae", display_pred=True,
+    prepare_pred=prepare_pred)
+interface.add_observer("after_epoch", update_board)
+interface.add_observer("after_epoch", sampling)
+test_history, train_history = interface.training(
+    manager=manager,
+    nb_epochs=10,
+    checkpointdir=None,
+    fold_index=0,
+    with_validation=True)
+
+#############################################################################
+# Conclusion
+# ----------
+#
+# We choose to add the one hot encoded vector directly as an input of the
+# model.
+# Well, this might be not the best option especially when we want to perform
+# representation learning. Indeed, in test time we want to provide an image as
+# input, and infer a latent vector. We can't provide the model
+# with the digit as input, since we won't know it in test time. We will
+# learn how to overcome this issue in the second CVAE tutorial.

--- a/examples/vae/vae_conditional_2.py
+++ b/examples/vae/vae_conditional_2.py
@@ -1,0 +1,408 @@
+"""
+Conditional Variational AutoEncoder (VAE)
+=========================================
+
+Credit: A Grigis
+
+Based on:
+
+- https://ravirajag.dev
+
+This tutorial is for the intuition of simple Variational Autoencoder(VAE)
+implementation in pynet.
+After reading this tutorial, you'll understand the technical details needed to
+implement conditional VAE.
+The main difference from the vanilla VAE is, in the vanilla case we generate
+image randomly, and here we can condition for which number we want to generate
+the image.
+
+Let’s begin with importing stuffs:
+"""
+
+import os
+import sys
+if "CI_MODE" in os.environ:
+    sys.exit()
+
+import numpy as np
+from scipy import ndimage
+import torch
+import torch.nn as nn
+import torch.nn.functional as func
+from pynet.datasets import DataManager, fetch_minst
+from pynet.interfaces import DeepLearningInterface
+from pynet.plotting import Board, update_board
+
+
+#############################################################################
+# The model will be trained on MNIST - handwritten digits dataset. The input
+# is an image in R(28×28).
+
+def flatten(arr):
+    return arr.flatten()
+
+data = fetch_minst(datasetdir="/neurospin/nsap/datasets/minst")
+manager = DataManager(
+    input_path=data.input_path,
+    metadata_path=data.metadata_path,
+    labels=["label"],
+    stratify_label="label",
+    number_of_folds=10,
+    batch_size=64,
+    test_size=0,
+    input_transforms=[flatten],
+    add_input=True,
+    sample_size=1)
+
+
+########################
+# The Model
+# ---------
+#
+# The model is composed of three sub-networks:
+# 1. Given x (image), encode it into a distribution over the latent space -
+#    referred to as Q(z|x).
+# 2. Given z in latent space (code representation of an image), decode it into
+#    the image it represents - referred to as f(z).
+# 3. Given x, classify its digit by mapping it to a layer of size 10 where the
+#    i'th value contains the probability of the i'th digit.
+#
+# The first two sub-networks are the vanilla VAE framework.
+#
+# The third one is used as an auxiliary task, which will enforce some of the
+# latent dimensions to encode the digit found in an image. 
+# In the vanilla VAE case we don't care what
+# information each dimension of the latent space holds. The model can learn
+# to encode whatever information it finds valuable for its task. Since we're
+# familiar with the dataset, we know the digit type should be important.
+# We want to help the model by providing it with this information. Moreover,
+# we'll use this information to generate images conditioned on the digit type,
+# as we will see later.
+# 
+# Given the digit type, we'll encode it using one hot encoding, that is, a
+# vector of size 10. These 10 numbers will be concatenated into the latent 
+# vector, so when decoding that vector into an image, the model will make use
+# of the digit information.
+#
+# There are two ways to provide the model with a one hot encoding vector:
+# 1. Add it as an input to the model.
+# 2. Add it as a label so the model will have to predict it by itself: add
+#    another sub-network that predicts a vector of size 10 where the loss is
+#    the cross entropy with the expected one hot vector.
+#
+# We'll go with the second option. Why? Well, in test time we can use the model
+# in two ways:
+# 1. Provide an image as input, and infer a latent vector.
+# 2. Provide a latent vector as input, and generate an image.
+#
+# Since we want to support the first option too, we can't provide the model
+# with the digit as input, since we won't know it in test time. Hence, the
+# model must learn to predict it.
+
+def idx2onehot(idx, n):
+    """ Given a class label, we will convert it into one-hot encoding.
+    """
+    assert idx.ndim == 1
+    assert torch.max(idx).item() < n
+    idx = idx.view(-1, 1)
+    onehot = torch.zeros(idx.size(0), n)
+    onehot.scatter_(1, idx.data, 1)
+
+    return onehot
+
+class Encoder(nn.Module):
+    """ This the encoder part of VAE.
+    """
+    def __init__(self, input_dim, hidden_dim, z_dim):
+        """ Init class.
+
+        Parameters
+        ----------
+        input_dim: int
+            the size of input (in case of MNIST 28 * 28).
+        hidden_dim: int
+            the size of hidden dimension.
+        z_dim: int
+            the latent dimension.
+        """
+        super().__init__()
+        self.linear = nn.Linear(input_dim, hidden_dim)
+        self.mu = nn.Linear(hidden_dim, z_dim)
+        self.var = nn.Linear(hidden_dim, z_dim)
+
+    def forward(self, x):
+        # x is of shape [batch_size, input_dim]
+        hidden = func.relu(self.linear(x))
+        # hidden is of shape [batch_size, hidden_dim]
+        z_mu = self.mu(hidden)
+        # z_mu is of shape [batch_size, latent_dim]
+        z_var = 1e-5 + torch.exp(self.var(hidden))
+        # the reason we exponentiate is because we need the variance to be
+        # positive. Any activation function whose range is the positive numbers
+        # could be used here.
+        # z_var is of shape [batch_size, latent_dim]
+
+        return z_mu, z_var
+
+class Decoder(nn.Module):
+    """ This the decoder part of VAE
+    """
+    def __init__(self, z_dim, hidden_dim, output_dim, n_classes):
+        """ Init class.
+
+        Parameters
+        ----------
+        z_dim: int
+            the latent size.
+        hidden_dim: int
+            the size of hidden dimension.
+        output_dim: int
+            the output dimension (in case of MNIST it is 28 * 28).
+        n_classes: int
+            the number of classes (dimension of one-hot representation of   
+            labels).
+        """
+        super().__init__()
+        self.latent_to_hidden = nn.Linear(z_dim + n_classes, hidden_dim)
+        self.hidden_to_out = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x):
+        # x is of shape [batch_size, latent_dim]
+        hidden = func.relu(self.latent_to_hidden(x))
+        # hidden is of shape [batch_size, hidden_dim]
+        predicted = torch.sigmoid(self.hidden_to_out(hidden))
+        # predicted is of shape [batch_size, output_dim]
+
+        return predicted
+
+class DigitClassifier(nn.Module):
+    """ This the digit classifer part of VAE
+    """
+    def __init__(self, input_dim, hidden_dim, n_classes):
+        """ Init class.
+
+        Parameters
+        ----------
+        input_dim: int
+            the size of input (in case of MNIST 28 * 28).
+        hidden_dim: int
+            the size of hidden dimension.
+        n_classes: int
+            the number of classes (dimension of one-hot representation of   
+            labels).
+        """
+        super().__init__()
+        self.linear1 = nn.Linear(input_dim, hidden_dim)
+        self.linear2 = nn.Linear(hidden_dim, n_classes)
+
+    def forward(self, x):
+        # x is of shape [batch_size, input_dim]
+        hidden = func.relu(self.linear1(x))
+        # hidden is of shape [batch_size, hidden_dim]
+        logits = self.linear2(hidden)
+        # logits is of shape [batch_size, n_classes]
+
+        return logits
+
+class CVAE(nn.Module):
+    """ This is the conditional VAE.
+    """
+    def __init__(self, input_dim, hidden_dim, latent_dim, n_classes):
+        """ Init class.
+
+        Parameters
+        ----------
+        input_dim: int
+            the size of input (in case of MNIST 28 * 28).
+        hidden_dim: int
+            the size of hidden dimension.
+        z_dim: int
+            the latent dimension.
+        n_classes: int
+            the number of classes (dimension of one-hot representation of   
+            labels).
+        """
+        super(CVAE, self).__init__()
+        self.encoder = Encoder(input_dim, hidden_dim, latent_dim)
+        self.decoder = Decoder(latent_dim, hidden_dim, input_dim, n_classes)
+        self.classifier = DigitClassifier(input_dim, hidden_dim, n_classes)
+
+    def forward(self, x):
+        # encode an image into a distribution over the latent space
+        z_mu, z_var = self.encoder(x)
+
+        # sample a latent vector from the latent space - using the
+        # reparameterization trick
+        # sample from the distribution having latent parameters z_mu, z_var
+        eps = torch.randn_like(z_var)
+        x_sample = z_mu + torch.sqrt(z_var) * eps
+    
+        # classify the digit
+        logits = self.classifier(x)
+        prob = func.softmax(logits)
+
+        # decode the latent vector - concatenated to the digits
+        # classification into an image
+        predicted = self.decoder(torch.cat([x_sample, prob], dim=1))
+
+        return predicted, {"z_mu": z_mu, "z_var": z_var, "logits": logits}
+
+########################
+# Loss
+# ----
+#
+# VAE consists of three loss functions:
+# 1. Reconstruction loss: how well we can reconstruct the image
+# 2. KL divergence: how off the distribution over the latent space is 
+#    from the prior. Given the prior is a standard Gaussian and the inferred
+#    distribution is a Gaussian with a diagonal covariance matrix,
+#    the KL-divergence becomes analytically solvable.
+# 3. Classification: how we predict classes. A classification weight is used
+#    to weight between the two losses, since there's a tension between them.
+
+class DecodeLoss(object):
+    def __init__(self, classification_weight):
+        super(DecodeLoss, self).__init__()
+        self.layer_outputs = None
+        self.classification_weight = classification_weight
+        self.auto_encode = VAELoss()
+        self.classification = ClassificationLoss()
+
+    def __call__(self, x_sample, x, y):
+        if self.layer_outputs is None:
+            raise ValueError("The model needs to return the latent space "
+                             "distribution parameters z_mu, z_var.")
+        self.auto_encode.layer_outputs = self.layer_outputs
+        self.classification.layer_outputs = self.layer_outputs
+        loss = (self.auto_encode(x_sample, x, y) + self.classification_weight *
+                self.classification(x_sample, x, y))
+
+        return loss
+
+class VAELoss(object):
+    def __init__(self):
+        super(VAELoss, self).__init__()
+        self.layer_outputs = None
+
+    def __call__(self, x_sample, x, y):
+        if self.layer_outputs is None:
+            raise ValueError("The model needs to return the latent space "
+                             "distribution parameters z_mu, z_var.")
+        z_mu = self.layer_outputs["z_mu"]
+        z_var = self.layer_outputs["z_var"]
+        # reconstruction loss
+        recon_loss = func.binary_cross_entropy(x_sample, x, reduction="sum")
+        # KL divergence loss
+        kl_loss = 0.5 * torch.sum(torch.exp(z_var) + z_mu**2 - 1.0 - z_var)
+        # encoder loss
+        loss_auto_encode = (recon_loss + kl_loss) / x_sample.size(0)
+
+        return loss_auto_encode.mean()
+
+class ClassificationLoss(object):
+    def __init__(self):
+        super(ClassificationLoss, self).__init__()
+        self.layer_outputs = None
+
+    def __call__(self, x_sample, x, y):
+        if self.layer_outputs is None:
+            raise ValueError("The model needs to return the latent space "
+                             "distribution parameters z_mu, z_var.")
+        logits = self.layer_outputs["logits"]
+        # classification
+        criterion = nn.CrossEntropyLoss(reduction="mean")
+        loss_classification = criterion(logits, y)
+
+        return loss_classification
+
+
+########################
+# Training
+# --------
+#
+# We'll train the model to optimize the losses - the VAE loss and the
+# classification loss - using Adam optimizer.
+#
+# At the end of every epoch we'll sample latent vectors and decode them into
+# images, so we can visualize how the generative power of the model improves
+# over the epochs. The sampling method is as follows:
+# 1. Deterministically set the dimensions which are used for digit
+#    classification according to the digit we want to generate an image for.
+#    If for example we want to generate an image of the digit 2, these
+#    dimensions will be set to [0010000000].
+# 2. Randomly sample the other dimensions according to the prior - a
+#    multivariate Gaussian. We'll use these sampled values for all the
+#    different digits we generate in a given epoch. This way we can have a
+#    feeling of what is encoded in the other dimensions, for example stroke
+#    style.
+#
+# The intuition behind step 1 is that after convergence the model should be
+# able to classify the digit in an input image using these dimensions. On the
+# other hand, these dimensions are also used in the decoding step to generate
+# the image. It means the decoder sub-network learns that when these
+# dimensions have the values corresponding to the digit 2, it should generate
+# an image of that digit. Therefore, if we manually set these dimensions to
+# contain the information of the digit 2, we'll get a generated image of that
+# digit.
+
+def prepare_pred(y_pred):
+    y_pred = y_pred[:3]
+    y_pred = y_pred.reshape(-1, 28, 28)
+    y_pred = np.asarray([ndimage.zoom(arr, 5, order=0) for arr in y_pred])
+    y_pred = np.expand_dims(y_pred, axis=1)
+    y_pred = (y_pred / y_pred.max()) * 255
+    return y_pred
+
+def sampling(signal):
+    """ Sample from the distribution and generate a image.
+    """
+    device = signal.object.device
+    model = signal.object.model
+    board = signal.object.board
+    # sample and generate a image
+    z = torch.randn(1, 20).to(device).repeat(10, 1)
+    y = torch.eye(10).to(device, dtype=z.dtype)
+    z = torch.cat((z, y), dim=1)
+    # run only the decoder
+    reconstructed_img = model.decoder(z)
+    img = reconstructed_img.view(-1, 28, 28).detach().numpy()
+    # display result
+    img = np.asarray([ndimage.zoom(arr, 5, order=0) for arr in img])
+    img = np.expand_dims(img, axis=1)
+    img = (img / img.max()) * 255
+    board.viewer.images(
+        img,
+        opts={
+            "title": "sampling",
+            "caption": "sampling"},
+        win="sampling")    
+
+model = CVAE(input_dim=(28 * 28), hidden_dim=128, latent_dim=20, n_classes=10)
+interface = DeepLearningInterface(
+    model=model,
+    optimizer_name="Adam",
+    learning_rate=0.001,
+    loss=DecodeLoss(classification_weight=30.),
+    metrics=[ClassificationLoss(), VAELoss()])
+interface.board = Board(
+    port=8097, host="http://localhost", env="vae", display_pred=True,
+    prepare_pred=prepare_pred)
+interface.add_observer("after_epoch", update_board)
+interface.add_observer("after_epoch", sampling)
+test_history, train_history = interface.training(
+    manager=manager,
+    nb_epochs=10,
+    checkpointdir=None,
+    fold_index=0,
+    with_validation=True)
+
+
+#############################################################################
+# Conclusion
+# ----------
+#
+# Using a simple feed forward network (no fancy convolutions) we're able to
+# generate nice looking images after 10 epochs. The model learned to use the
+# special digit dimensions quite fast and we already see the sequence of
+# digits we were trying to generate.
+

--- a/examples/vae/vae_moe.py
+++ b/examples/vae/vae_moe.py
@@ -1,0 +1,366 @@
+"""
+Unsupervised Conditional Variational AutoEncoder (VAE)
+======================================================
+
+Credit: A Grigis
+
+Based on:
+
+- https://ravirajag.dev
+
+The Variational Autoencoder (VAE) is a  neural networks that try to learn the
+shape of the input space. Once trained, the model can be used to generate
+new samples from the input space.
+
+If we have labels for our input data, it’s also possible to condition the
+generation process on the label. The idea here is to achieve the same results
+using an unsupervised approach.
+
+Mixture of Experts
+------------------
+
+MoE is a supervised learning framework. MoE relies on the possibility that the
+input might be segmented according to the x->y mapping. How can we train a
+model that learns the split points while at the same time learns the mapping
+that defines the split points.
+
+MoE does so using an architecture of multiple subnetworks - one manager and
+multiple experts. The manager maps the input into a soft decision over the
+experts, which is used in two contexts:
+1. The output of the network is a weighted average of the experts' outputs,
+   where the weights are the manager's output.
+2. The loss function is $\sum_i p_i(y - \bar{y_i})^2$. y is the label,
+   $\bar{y_i}$ is the output of the i'th expert, $p_i$ is the i'th entry of
+   the manager's output. When you differentiate the loss, you get these
+   results: a) the manager decides for each expert how much it contributes to
+   the loss. In other words, the manager chooses which experts should tune
+   their weights according to their error, and b) the manager tunes the
+   probabilities it outputs in such a way that the experts that got it right
+   will get higher probabilities than those that didn’t. This loss function
+   encourages the experts to specialize in different kinds of inputs.
+
+MoE is a framework for supervised learning. Surely we can change y to be x for
+the unsupervised case, right? MoE's power stems from the fact that each expert
+specializes in a different segment of the input space with a unique mapping
+x ->y. If we use the mapping x->x, each expert will specialize in a different
+segment of the input space with unique patterns in the input itself.
+
+We'll use VAEs as the experts. Part of the VAE’s loss is the reconstruction
+loss, where the VAE tries to reconstruct the original input image x.
+
+A cool byproduct of this architecture is that the manager can classify the
+digit found in an image using its output vector!
+
+One thing we need to be careful about when training this model is that the
+manager could easily degenerate into outputting a constant vector -
+regardless of the input in hand. This results in one VAE specialized in all
+digits, and nine VAEs specialized in nothing. One way to mitigate it, which
+is described in the MoE paper, is to add a balancing term to the loss.
+It encourages the outputs of the manager over a batch of inputs to
+be balanced: $\sum_\text{examples in batch} \vec{p} \approx Uniform$.
+
+Let’s begin with importing stuffs:
+"""
+
+import os
+import sys
+if "CI_MODE" in os.environ:
+    sys.exit()
+
+import numpy as np
+from scipy import ndimage
+import torch
+import torch.nn as nn
+import torch.nn.functional as func
+from pynet.datasets import DataManager, fetch_minst
+from pynet.interfaces import DeepLearningInterface
+from pynet.plotting import Board, update_board
+
+
+#############################################################################
+# The model will be trained on MNIST - handwritten digits dataset. The input
+# is an image in R(28×28).
+
+def flatten(arr):
+    return arr.flatten()
+
+data = fetch_minst(datasetdir="/neurospin/nsap/datasets/minst")
+manager = DataManager(
+    input_path=data.input_path,
+    metadata_path=data.metadata_path,
+    stratify_label="label",
+    number_of_folds=10,
+    batch_size=64,
+    test_size=0,
+    input_transforms=[flatten],
+    add_input=True,
+    sample_size=0.05)
+
+
+#############################################################################
+# The Model
+# ---------
+#
+# The model is composed of two sub-networks:
+# 1. Given x (image), encode it into a distribution over the latent space -
+#    referred to as Q(z|x).
+# 2. Given z in latent space (code representation of an image), decode it into
+#    the image it represents - referred to as f(z).
+#
+# We want to enforce some of the latent dimensions to encode the digit found
+# in an image. In the vanilla VAE case we don't care what
+# information each dimension of the latent space holds. The model can learn
+# to encode whatever information it finds valuable for its task. Since we're
+# familiar with the dataset, we know the digit type should be important.
+# We want to help the model by providing it with this information. Moreover,
+# we'll use this information to generate images conditioned on the digit type,
+# as we will see later.
+# 
+# Given the digit type, we'll encode it using one hot encoding, that is, a
+# vector of size 10. These 10 numbers will be concatenated into the latent 
+# vector, so when decoding that vector into an image, the model will make use
+# of the digit information.
+#
+# There are two ways to provide the model with a one hot encoding vector:
+# 1. Add it as an input to the model.
+# 2. Add it as a label so the model will have to predict it by itself: add
+#    another sub-network that predicts a vector of size 10 where the loss is
+#    the cross entropy with the expected one hot vector.
+#
+# We'll go with the first option first.
+
+def idx2onehot(idx, n):
+    """ Given a class label, we will convert it into one-hot encoding.
+    """
+    assert idx.ndim == 1
+    assert torch.max(idx).item() < n
+    idx = idx.view(-1, 1)
+    onehot = torch.zeros(idx.size(0), n)
+    onehot.scatter_(1, idx.data, 1)
+
+    return onehot
+
+class Encoder(nn.Module):
+    """ This the encoder part of VAE.
+    """
+    def __init__(self, input_dim, hidden_dim, latent_dim):
+        """ Init class.
+
+        Parameters
+        ----------
+        input_dim: int
+            the size of input (in case of MNIST 28 * 28).
+        hidden_dim: int
+            the size of hidden dimension.
+        latent_dim: int
+            the latent dimension.
+        """
+        super().__init__()
+        self.linear = nn.Linear(input_dim, hidden_dim)
+        self.mu = nn.Linear(hidden_dim, latent_dim)
+        self.var = nn.Linear(hidden_dim, latent_dim)
+
+    def forward(self, x):
+        # x is of shape [batch_size, input_dim]
+        hidden = func.relu(self.linear(x))
+        # hidden is of shape [batch_size, hidden_dim]
+        z_mu = self.mu(hidden)
+        # z_mu is of shape [batch_size, latent_dim]
+        z_var = self.var(hidden)
+        # z_var is of shape [batch_size, latent_dim]
+
+        return z_mu, z_var
+
+class Decoder(nn.Module):
+    """ This the decoder part of VAE
+    """
+    def __init__(self, latent_dim, hidden_dim, output_dim):
+        """ Init class.
+
+        Parameters
+        ----------
+        latent_dim: int
+            the latent size.
+        hidden_dim: int
+            the size of hidden dimension.
+        output_dim: int
+            the output dimension (in case of MNIST it is 28 * 28).
+        """
+        super().__init__()
+        self.latent_to_hidden = nn.Linear(latent_dim, hidden_dim)
+        self.hidden_to_out = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x):
+        # x is of shape [batch_size, latent_dim]
+        hidden = func.relu(self.latent_to_hidden(x))
+        # hidden is of shape [batch_size, hidden_dim]
+        predicted = torch.sigmoid(self.hidden_to_out(hidden))
+        # predicted is of shape [batch_size, output_dim]
+
+        return predicted
+
+class VAE(nn.Module):
+    """ This is the VAE.
+    """
+    def __init__(self, input_dim, hidden_dim, latent_dim):
+        """ Init class.
+
+        Parameters
+        ----------
+        input_dim: int
+            the size of input (in case of MNIST 28 * 28).
+        hidden_dim: int
+            the size of hidden dimension.
+        latent_dim: int
+            the latent dimension.
+        """
+        super(VAE, self).__init__()
+        self.encoder = Encoder(input_dim, hidden_dim, latent_dim)
+        self.decoder = Decoder(latent_dim, hidden_dim, input_dim)
+
+    def forward(self, x):
+        # encode an image into a distribution over the latent space
+        z_mu, z_var = self.encoder(x)
+
+        # sample a latent vector from the latent space - using the
+        # reparameterization trick
+        # sample from the distribution having latent parameters z_mu, z_var
+        std = torch.exp(z_var / 2)
+        eps = torch.randn_like(std)
+        x_sample = eps.mul(std).add_(z_mu)
+
+        # decode the latent vector - concatenated to the digits
+        # classification into an image
+        predicted = self.decoder(x_sample)
+
+        return predicted, {"z_mu": z_mu, "z_var": z_var}
+
+class VAELoss(object):
+    def __init__(self):
+        super(VAELoss, self).__init__()
+        self.layer_outputs = None
+
+    def __call__(self, x_sample, x):
+        if self.layer_outputs is None:
+            raise ValueError("The model needs to return the latent space "
+                             "distribution parameters z_mu, z_var.")
+        z_mu = self.layer_outputs["z_mu"]
+        z_var = self.layer_outputs["z_var"]
+        # reconstruction loss
+        recon_loss = func.binary_cross_entropy(x_sample, x, reduction="sum")
+        # KL divergence loss
+        kl_loss = 0.5 * torch.sum(torch.exp(z_var) + z_mu**2 - 1.0 - z_var)
+
+        return recon_loss + kl_loss
+
+class Manager(nn.Module):
+    def __init__(self, input_dim, hidden_dim, experts):
+        """ Init class.
+
+        Parameters
+        ----------
+        input_dim: int
+            the size of input (in case of MNIST 28 * 28).
+        hidden_dim: int
+            the size of hidden dimension.
+        experts: list of VAE
+            the manager experts.
+        """
+        super(Manager, self).__init__()
+        self._experts = experts
+        self._experts_results = []
+        self.linear1 = nn.Linear(input_dim, hidden_dim)
+        self.linear2 = nn.Linear(hidden_dim, len(experts))
+        
+    def forward(self, x):
+        hidden = func.relu(self.linear1(x))
+        logits = self.linear2(hidden)
+        probs = func.softmax(logits, dim=1)
+        self._experts_results = []
+        for net in self._experts:
+            self._experts_results.append(net(x))
+        return probs, {"experts_results": self._experts_results}
+
+class ManagerLoss(object):
+    def __init__(self, balancing_weight=0.1):
+        """ Init class.
+
+        Parameters
+        ----------
+        balancing_weight: float, default 0.1    
+            how much the balancing term will contribute to the loss.
+        """
+        super(ManagerLoss, self).__init__()
+        self.layer_outputs = None
+        self.balancing_weight = balancing_weight
+
+    def __call__(self, probs, x):
+        if self.layer_outputs is None:
+            raise ValueError("The model needs to return the latent space "
+                             "distribution parameters z_mu, z_var.")
+        losses = []
+        criterion = VAELoss()
+        for result in self.layer_outputs["experts_results"]:
+            criterion.layer_outputs = result[1]
+            losses.append(criterion(result[0], x).view(-1, 1))
+        losses = torch.cat(losses, dim=1)
+        expected_expert_loss = torch.sum(losses * probs, dim=1).mean()
+        experts_importance = torch.sum(probs, dim=0)
+        balancing_loss = experts_importance.std(dim=0)
+        loss = expected_expert_loss + self.balancing_weight * balancing_loss
+
+        return loss
+
+
+#############################################################################
+# Training
+# --------
+#
+# We'll train the model to optimize the losses using Adam optimizer.
+
+def sampling(signal):
+    """ Sample from the distribution and generate a image.
+    """
+    device = signal.object.device
+    experts = signal.object.model._experts
+    board = signal.object.board
+    # sample and generate a image
+    z = torch.randn(1, 20).to(device)
+    # run only the decoder
+    images = []
+    for model in experts:
+        reconstructed_img = model.decoder(z)
+        img = reconstructed_img.view(-1, 28, 28).detach().numpy()
+        img = np.asarray([ndimage.zoom(arr, 5, order=0) for arr in img])        
+        images.append(img)
+    # display result
+    images = np.asarray(images)
+    images = (images / images.max()) * 255
+    board.viewer.images(
+        images,
+        opts={
+            "title": "sampling",
+            "caption": "sampling"},
+        win="sampling")    
+
+experts = [
+    VAE(input_dim=(28 * 28), hidden_dim=128, latent_dim=20) for idx in range(10)]
+model = Manager(input_dim=(28 * 28), hidden_dim=128, experts=experts)
+interface = DeepLearningInterface(
+    model=model,
+    optimizer_name="Adam",
+    learning_rate=0.001,
+    loss=ManagerLoss(balancing_weight=0.1))
+interface.board = Board(
+    port=8097, host="http://localhost", env="vae")
+interface.add_observer("after_epoch", update_board)
+interface.add_observer("after_epoch", sampling)
+test_history, train_history = interface.training(
+    manager=manager,
+    nb_epochs=10,
+    checkpointdir=None,
+    fold_index=0,
+    with_validation=True)
+
+
+

--- a/examples/vae/vae_vanilla.py
+++ b/examples/vae/vae_vanilla.py
@@ -1,0 +1,251 @@
+"""
+Vanilla Variational AutoEncoder (VAE)
+=====================================
+
+Credit: A Grigis
+
+Based on:
+
+- https://ravirajag.dev
+
+This tutorial is for the intuition of simple Variational Autoencoder (VAE)
+implementation in pynet.
+After reading this tutorial, you'll understand the technical details needed to
+implement VAE.
+
+Let’s begin with importing stuffs:
+"""
+
+import os
+import sys
+if "CI_MODE" in os.environ:
+    sys.exit()
+
+import numpy as np
+from scipy import ndimage
+import torch
+import torch.nn as nn
+import torch.nn.functional as func
+from pynet.datasets import DataManager, fetch_minst
+from pynet.interfaces import DeepLearningInterface
+from pynet.plotting import Board, update_board
+
+
+#############################################################################
+# The model will be trained on MNIST - handwritten digits dataset. The input
+# is an image in R(28×28).
+
+def flatten(arr):
+    return arr.flatten()
+
+data = fetch_minst(datasetdir="/neurospin/nsap/datasets/minst")
+manager = DataManager(
+    input_path=data.input_path,
+    metadata_path=data.metadata_path,
+    stratify_label="label",
+    number_of_folds=10,
+    batch_size=64,
+    test_size=0,
+    input_transforms=[flatten],
+    add_input=True,
+    sample_size=1)
+
+
+#############################################################################
+# The Model
+# ---------
+#
+# The model is composed of two sub-networks:
+# 1. Given x (image), encode it into a distribution over the latent space -
+#    referred to as Q(z|x).
+# 2. Given z in latent space (code representation of an image), decode it into
+#    the image it represents - referred to as f(z).
+
+class Encoder(nn.Module):
+    """ This the encoder part of VAE.
+    """
+    def __init__(self, input_dim, hidden_dim, latent_dim):
+        """ Init class.
+
+        Parameters
+        ----------
+        input_dim: int
+            the size of input (in case of MNIST 28 * 28).
+        hidden_dim: int
+            the size of hidden dimension.
+        latent_dim: int
+            the latent dimension.
+        """
+        super(Encoder, self).__init__()
+        self.linear = nn.Linear(input_dim, hidden_dim)
+        self.mu = nn.Linear(hidden_dim, latent_dim)
+        self.var = nn.Linear(hidden_dim, latent_dim)
+
+    def forward(self, x):
+        # x is of shape [batch_size, input_dim]
+        hidden = func.relu(self.linear(x))
+        # hidden is of shape [batch_size, hidden_dim]
+        z_mu = self.mu(hidden)
+        # z_mu is of shape [batch_size, latent_dim]
+        z_var = self.var(hidden)
+        # z_var is of shape [batch_size, latent_dim]
+
+        return z_mu, z_var
+
+class Decoder(nn.Module):
+    """ This the decoder part of VAE.
+    """
+    def __init__(self, latent_dim, hidden_dim, output_dim):
+        """ Init class.
+
+        Parameters
+        ----------
+        latent_dim: int
+            the latent size.
+        hidden_dim: int
+            the size of hidden dimension.
+        output_dim: int
+            the output dimension (in case of MNIST it is 28 * 28).
+        """
+        super(Decoder, self).__init__()
+        self.latent_to_hidden = nn.Linear(latent_dim, hidden_dim)
+        self.hidden_to_out = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x):
+        # x is of shape [batch_size, latent_dim]
+        hidden = func.relu(self.latent_to_hidden(x))
+        # hidden is of shape [batch_size, hidden_dim]
+        predicted = torch.sigmoid(self.hidden_to_out(hidden))
+        # predicted is of shape [batch_size, output_dim]
+
+        return predicted
+
+class VAE(nn.Module):
+    """ This the VAE, which takes an encoder and a decoder.
+    """
+    def __init__(self, input_dim, hidden_dim, latent_dim):
+        """ Init class.
+
+        Parameters
+        ----------
+        input_dim: int
+            the size of input (in case of MNIST 28 * 28).
+        hidden_dim: int
+            the size of hidden dimension.
+        latent_dim: int
+            the latent dimension.
+        """
+        super(VAE, self).__init__()
+        self.encorder = Encoder(input_dim, hidden_dim, latent_dim)
+        self.decorder = Decoder(latent_dim, hidden_dim, input_dim)
+
+    def forward(self, x):
+        # encode an image into a distribution over the latent space
+        z_mu, z_var = self.encorder(x)
+        # sample a latent vector from the latent space - using the
+        # reparameterization trick
+        # sample from the distribution having latent parameters z_mu, z_var
+        std = torch.exp(z_var / 2)
+        eps = torch.randn_like(std)
+        x_sample = eps.mul(std).add_(z_mu)
+        # decode the latent vector 
+        predicted = self.decorder(x_sample)
+
+        return predicted, {"z_mu": z_mu, "z_var": z_var}
+
+
+#############################################################################
+# Loss
+# ----
+#
+# VAE consists of two loss functions:
+# 1. Reconstruction loss: how well we can reconstruct the image
+# 2. KL divergence loss: how off the distribution over the latent space is 
+#    from the prior. Given the prior is a standard Gaussian and the inferred
+#    distribution is a Gaussian with a diagonal covariance matrix,
+#    the KL-divergence becomes analytically solvable.
+
+class DecodeLoss(object):
+    def __init__(self):
+        super(DecodeLoss, self).__init__()
+        self.layer_outputs = None
+
+    def __call__(self, x_sample, x):
+        if self.layer_outputs is None:
+            raise ValueError("The model needs to return the latent space "
+                             "distribution parameters z_mu, z_var.")
+        z_mu = self.layer_outputs["z_mu"]
+        z_var = self.layer_outputs["z_var"]
+        # reconstruction loss
+        recon_loss = func.binary_cross_entropy(x_sample, x, reduction="sum")
+        # KL divergence loss
+        kl_loss = 0.5 * torch.sum(torch.exp(z_var) + z_mu**2 - 1.0 - z_var)
+
+        return recon_loss + kl_loss
+
+
+#############################################################################
+# Training
+# --------
+#
+# We'll train the model to optimize the losses using Adam optimizer.
+
+def prepare_pred(y_pred):
+    y_pred = y_pred[:3]
+    y_pred = y_pred.reshape(-1, 28, 28)
+    y_pred = np.asarray([ndimage.zoom(arr, 5, order=0) for arr in y_pred])
+    y_pred = np.expand_dims(y_pred, axis=1)
+    y_pred = (y_pred / y_pred.max()) * 255
+    return y_pred
+
+def sampling(signal):
+    """ Sample from the distribution and generate a image.
+    """
+    device = signal.object.device
+    model = signal.object.model
+    board = signal.object.board
+    # sample and generate a image
+    z = torch.randn(1, 20).to(device)
+    # run only the decoder
+    reconstructed_img = model.decorder(z)
+    img = reconstructed_img.view(28, 28).detach().numpy()
+    # display result
+    img = ndimage.zoom(img, 5, order=0)
+    img = np.expand_dims(img, axis=0)
+    img = np.expand_dims(img, axis=0)
+    img = (img / img.max()) * 255
+    board.viewer.images(
+        img,
+        opts={
+            "title": "sampling",
+            "caption": "sampling"},
+        win="sampling")    
+
+model = VAE(input_dim=(28 * 28), hidden_dim=128, latent_dim=20)
+interface = DeepLearningInterface(
+    model=model,
+    optimizer_name="Adam",
+    learning_rate=0.001,
+    loss=DecodeLoss())
+interface.board = Board(
+    port=8097, host="http://localhost", env="vae", display_pred=True,
+    prepare_pred=prepare_pred)
+interface.add_observer("after_epoch", update_board)
+interface.add_observer("after_epoch", sampling)
+test_history, train_history = interface.training(
+    manager=manager,
+    nb_epochs=10,
+    checkpointdir=None,
+    fold_index=0,
+    with_validation=True)
+
+
+#############################################################################
+# Conclusion
+# ----------
+#
+# Using a simple feed forward network (no fancy convolutions) we're able to
+# generate nice looking images after 10 epochs. We generate
+# image randomly. We will see in a next tutorial how to add a condition on
+# the number we want to generate the image.
+

--- a/examples/vae/vae_vanilla.py
+++ b/examples/vae/vae_vanilla.py
@@ -48,7 +48,7 @@ manager = DataManager(
     test_size=0,
     input_transforms=[flatten],
     add_input=True,
-    sample_size=1)
+    sample_size=0.05)
 
 
 #############################################################################

--- a/pynet/datasets/__init__.py
+++ b/pynet/datasets/__init__.py
@@ -36,6 +36,7 @@ from .hcp import fetch_hcp_brain
 from .metastasis import fetch_metastasis
 from .toy import fetch_toy
 from .tcga_lgg_tif import fetch_tcga_lgg_tif
+from .minst import fetch_minst
 
 
 def get_fetchers():

--- a/pynet/datasets/cifar.py
+++ b/pynet/datasets/cifar.py
@@ -8,7 +8,7 @@
 ##########################################################################
 
 """
-Module that provides functions to prepare the Brats dataset.
+Module that provides functions to prepare the CIFAR dataset.
 """
 
 # Imports

--- a/pynet/datasets/minst.py
+++ b/pynet/datasets/minst.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+##########################################################################
+# NSAp - Copyright (C) CEA, 2020
+# Distributed under the terms of the CeCILL-B license, as published by
+# the CEA-CNRS-INRIA. Refer to the LICENSE file or to
+# http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html
+# for details.
+##########################################################################
+
+"""
+Module that provides functions to prepare the MINST dataset.
+"""
+
+# Imports
+import os
+import json
+import logging
+import torchvision
+import torchvision.transforms as transforms
+from collections import namedtuple
+from collections import OrderedDict
+import numpy as np
+import pandas as pd
+import urllib
+from pynet.datasets import Fetchers
+
+
+# Global parameters
+Item = namedtuple("Item", ["input_path", "output_path", "metadata_path"])
+logger = logging.getLogger("pynet")
+
+
+@Fetchers.register
+def fetch_minst(datasetdir):
+    """ Fetch/prepare the MINST dataset for pynet.
+
+    Parameters
+    ----------
+    datasetdir: str
+        the dataset destination folder.
+
+    Returns
+    -------
+    item: namedtuple
+        a named tuple containing 'input_path', and 'metadata_path',
+    """
+    logger.info("Loading minst dataset.")
+    if not os.path.isdir(datasetdir):
+        os.mkdir(datasetdir)
+    desc_path = os.path.join(datasetdir, "pynet_minst.tsv")
+    input_path = os.path.join(datasetdir, "pynet_minst_inputs.npy")
+    if not os.path.isfile(desc_path):
+        transform = transforms.Compose([
+            transforms.ToTensor()
+        ])
+        logger.info("Getting train dataset.")
+        trainset = torchvision.datasets.MNIST(
+            root=datasetdir,
+            train=True,
+            download=True,
+            transform=transform)
+        logger.info("Getting test dataset.")
+        testset = torchvision.datasets.MNIST(
+            root=datasetdir,
+            train=False,
+            download=True,
+            transform=transform)
+        metadata = dict((key, []) for key in ("label", ))
+        data = []
+        for loader in (trainset, testset):
+            for arr, label in loader:
+                logger.debug("Processing {0} {1}...".format(label, arr.shape))
+                data.append(arr.numpy())
+                metadata["label"].append(label)
+        data = np.asarray(data)
+        np.save(input_path, data)
+        df = pd.DataFrame.from_dict(metadata)
+        df.to_csv(desc_path, sep="\t", index=False)
+    return Item(input_path=input_path, output_path=None,
+                metadata_path=desc_path)

--- a/pynet/datasets/tcga_lgg_tif.py
+++ b/pynet/datasets/tcga_lgg_tif.py
@@ -65,6 +65,13 @@ def get_subjects_files(datadir):
 def fetch_tcga_lgg_tif(datasetdir):
     """ Fetch/prepare the TCA-LGG-tif dataset for pynet.
 
+    The patient average age was 47 with an almost even split between women and
+    men (56 vs. 53, 1 unknown) in our dataset. Histologically, the tumors were
+    divided between oligodendroglioma (47), astrocytoma (33), and
+    oligoastrocytoma (29). Histology of one tumor was unknown. The data
+    included grade II (51) and grade III (58) tumors with grade of one tumor
+    unknown.
+
     Parameters
     ----------
     datasetdir: str

--- a/pynet/interfaces.py
+++ b/pynet/interfaces.py
@@ -112,7 +112,7 @@ class DeepLearningInterface(Base, metaclass=DeepLearningMetaRegister):
     __net__ = None
 
     def __init__(self, net_params=None, pretrained=None, resume=False,
-                 optimizer_name="Adam", learning_rate=1e-3,
+                 add_labels=False, optimizer_name="Adam", learning_rate=1e-3,
                  loss_name="NLLLoss", metrics=None, use_cuda=False, **kwargs):
         """ Class initilization.
 
@@ -126,6 +126,9 @@ class DeepLearningInterface(Base, metaclass=DeepLearningMetaRegister):
             if set to true, the code will restore the weights of the model
             but also restore the optimizer's state, as well as the
             hyperparameters used, and the scheduler.
+        add_labels: bool, default False
+            if set and labels are specified in the data manager, add the labels
+            to the forward function parameters.
         optimizer_name: str, default 'Adam'
             the name of the optimizer: see 'torch.optim' for a description
             of available optimizer.
@@ -158,6 +161,7 @@ class DeepLearningInterface(Base, metaclass=DeepLearningMetaRegister):
             use_cuda=use_cuda,
             pretrained=pretrained,
             resume=resume,
+            add_labels=add_labels,
             **kwargs)
 
 


### PR DESCRIPTION
Add support and examples for VAE:
- add MINST dataset.
- change core and interface to allow vae training/testing.
- allow GPU pretrained model loading on CPU.
- add vanilla VAE feed forward example.
- add two conditional VAE feed forward examples.
- add mean of epxerts (MoE) VAE feed forward example.