### PR TITLE
[Augmentation] Remove double definition of `random_zooms` and fix deprecation issues

### DIFF
--- a/pynet/augmentation/intensity.py
+++ b/pynet/augmentation/intensity.py
@@ -329,7 +329,7 @@ def add_motion(arr, rotation=10, translation=10, n_transforms=2,
     for cnt in range(n_transforms):
         random_rotations = Rotation.from_euler(
             "xyz", random_rotations[cnt], degrees=True)
-        random_rotations = random_rotations.as_dcm()
+        random_rotations = random_rotations.as_matrix()
         zoom = [1, 1, 1]
         affine = compose(random_translations[cnt], random_rotations, zoom)
         flow = affine_flow(affine, shape)

--- a/pynet/augmentation/spatial.py
+++ b/pynet/augmentation/spatial.py
@@ -65,7 +65,7 @@ def affine(arr, rotation=10, translation=10, zoom=0.2, order=3, dist="uniform",
         low=(1 - zoom), high=(1 + zoom), size=arr.ndim)
     random_rotations = Rotation.from_euler(
         "xyz", random_rotations, degrees=True)
-    random_rotations = random_rotations.as_dcm()
+    random_rotations = random_rotations.as_matrix()
     affine = compose(random_translations, random_rotations, random_zooms)
     shape = arr.shape
     flow = affine_flow(affine, shape)

--- a/pynet/augmentation/spatial.py
+++ b/pynet/augmentation/spatial.py
@@ -60,8 +60,6 @@ def affine(arr, rotation=10, translation=10, zoom=0.2, order=3, dist="uniform",
         rotation, arr.ndim, dist=dist, seed=seed)
     random_translations = random_generator(
         translation, arr.ndim, dist=dist, seed=seed)
-    random_zooms = random_generator(
-        translation, arr.ndim, dist=dist, seed=seed)
     np.random.seed(seed)
     random_zooms = np.random.uniform(
         low=(1 - zoom), high=(1 + zoom), size=arr.ndim)


### PR DESCRIPTION
Hi,

Just a quick fix for issues I encountered:
- `random_zooms` was defined twice and overwritten (see https://github.com/neurospin/pynet/issues/15),
- `as_dcm()` is deprecated: it has been renamed `as_matrix()` in SciPy 1.4.0 and has been removed in SciPy 1.6.0.